### PR TITLE
Change endpoint host to stop it redirecting to digital-public-works

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,7 +10,7 @@ use Mix.Config
 # which you should run after static files are built and
 # before starting your production server.
 config :digital_public_works, DigitalPublicWorksWeb.Endpoint,
-  url: [scheme: "https", host: "digital-public-works", port: 443],
+  url: [scheme: "https", host: "digitalpublicworks.com", port: 443],
   force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/cache_manifest.json"
 


### PR DESCRIPTION
The current production environment is redirecting to `https://digital-public-works` when it tries to redirect people away from `http://`. This fixes that issue by changing the host configuration in the production endpoint configuration.