### PR TITLE
First pass at project review

### DIFF
--- a/lib/digital_public_works/accounts/user.ex
+++ b/lib/digital_public_works/accounts/user.ex
@@ -11,6 +11,7 @@ defmodule DigitalPublicWorks.Accounts.User do
     field :email, :string
     field :password, :string, virtual: true
     field :password_hash, :string
+    field :is_admin, :boolean, default: :false
     has_many :projects, Project
 
     timestamps()

--- a/lib/digital_public_works/projects.ex
+++ b/lib/digital_public_works/projects.ex
@@ -39,7 +39,7 @@ defmodule DigitalPublicWorks.Projects do
     |> Repo.all
   end
 
-  defp filter_projects(query, []), do: query
+  defp filter_projects(query, nil), do: query
 
   defp filter_projects(query, search) do
     from p in query, where: ilike(p.title, ^"%#{search}%")

--- a/lib/digital_public_works/projects.ex
+++ b/lib/digital_public_works/projects.ex
@@ -18,31 +18,31 @@ defmodule DigitalPublicWorks.Projects do
       [%Project{}, ...]
 
   """
-  def list_projects(_filter \\ nil, _ \\ nil)
+  def list_projects(_user \\ nil, _search \\ nil)
 
-  def list_projects(filter, nil) do
+  def list_projects(nil, search) do
     Project
     |> where(is_public: true)
-    |> filter_projects(filter)
+    |> filter_projects(search)
     |> Repo.all
   end
 
-  def list_projects(filter, %User{is_admin: true}) do
+  def list_projects(%User{is_admin: true}, search) do
     Project
-    |> filter_projects(filter)
+    |> filter_projects(search)
     |> Repo.all
   end
 
-  def list_projects(filter, %User{id: user_id}) do
+  def list_projects(%User{id: user_id}, search) do
     (from p in Project, where: p.is_public == true or p.user_id == ^user_id)
-    |> filter_projects(filter)
+    |> filter_projects(search)
     |> Repo.all
   end
 
-  defp filter_projects(query, nil), do: query
+  defp filter_projects(query, []), do: query
 
-  defp filter_projects(query, filter) do
-    from p in query, where: ilike(p.title, ^"%#{filter}%")
+  defp filter_projects(query, search) do
+    from p in query, where: ilike(p.title, ^"%#{search}%")
   end
 
   @doc """

--- a/lib/digital_public_works/projects/project.ex
+++ b/lib/digital_public_works/projects/project.ex
@@ -22,7 +22,7 @@ defmodule DigitalPublicWorks.Projects.Project do
   @doc false
   def changeset(project, attrs) do
     project
-    |> cast(attrs, [:title, :body, :is_public])
+    |> cast(attrs, [:title, :body])
     |> validate_required([:title, :body])
     |> unique_constraint(:title)
   end

--- a/lib/digital_public_works/projects/project.ex
+++ b/lib/digital_public_works/projects/project.ex
@@ -12,6 +12,7 @@ defmodule DigitalPublicWorks.Projects.Project do
     field :body, :string
     field :title, :string
     field :is_featured, :boolean
+    field :is_public, :boolean, default: :false
     belongs_to :user, User
     has_many :posts, Post
 
@@ -21,7 +22,7 @@ defmodule DigitalPublicWorks.Projects.Project do
   @doc false
   def changeset(project, attrs) do
     project
-    |> cast(attrs, [:title, :body])
+    |> cast(attrs, [:title, :body, :is_public])
     |> validate_required([:title, :body])
     |> unique_constraint(:title)
   end

--- a/lib/digital_public_works_web/controllers/project_controller.ex
+++ b/lib/digital_public_works_web/controllers/project_controller.ex
@@ -33,7 +33,10 @@ defmodule DigitalPublicWorksWeb.ProjectController do
   end
 
   def index(conn, params) do
-    projects = Projects.list_projects(params["project"]["q"])
+    query = params["project"]["q"]
+
+    projects = Projects.list_projects(query, conn.assigns.current_user)
+
     render(conn, "index.html", projects: projects)
   end
 
@@ -87,5 +90,25 @@ defmodule DigitalPublicWorksWeb.ProjectController do
     conn
     |> put_flash(:info, "Project deleted successfully.")
     |> redirect(to: Routes.project_path(conn, :index))
+  end
+
+  def publish(conn, _params) do
+    project = conn.assigns.project
+
+    {:ok, _project} = Projects.publish_project(project)
+
+    conn
+    |> put_flash(:info, "Project published successfully.")
+    |> redirect(to: Routes.project_path(conn, :show, project))
+  end
+
+  def unpublish(conn, _params) do
+    project = conn.assigns.project
+
+    {:ok, _project} = Projects.unpublish_project(project)
+
+    conn
+    |> put_flash(:info, "Project unpublished successfully.")
+    |> redirect(to: Routes.project_path(conn, :show, project))
   end
 end

--- a/lib/digital_public_works_web/controllers/project_controller.ex
+++ b/lib/digital_public_works_web/controllers/project_controller.ex
@@ -33,9 +33,9 @@ defmodule DigitalPublicWorksWeb.ProjectController do
   end
 
   def index(conn, params) do
-    query = params["project"]["q"]
+    search = params["project"]["q"]
 
-    projects = Projects.list_projects(query, conn.assigns.current_user)
+    projects = Projects.list_projects(conn.assigns.current_user, search)
 
     render(conn, "index.html", projects: projects)
   end

--- a/lib/digital_public_works_web/permission.ex
+++ b/lib/digital_public_works_web/permission.ex
@@ -1,5 +1,5 @@
 defmodule DigitalPublicWorksWeb.Permission do
-  
+
   alias DigitalPublicWorks.Projects.Project
   alias DigitalPublicWorks.Posts.Post
 
@@ -8,7 +8,11 @@ defmodule DigitalPublicWorksWeb.Permission do
       action in [:show, :index] -> true
       action in [:new, :create] -> user
       action in [:edit, :update, :delete] ->
-        user && user.id == project.user_id || user.is_admin
+        user && user.id == project.user_id
+      action in [:publish] ->
+        user && user.is_admin && !project.is_public
+      action in [:unpublish] ->
+        user && user.is_admin && project.is_public
       true -> false
     end
   end

--- a/lib/digital_public_works_web/permission.ex
+++ b/lib/digital_public_works_web/permission.ex
@@ -7,7 +7,8 @@ defmodule DigitalPublicWorksWeb.Permission do
     cond do
       action in [:show, :index] -> true
       action in [:new, :create] -> user
-      action in [:edit, :update, :delete] -> user && user.id == project.user_id
+      action in [:edit, :update, :delete] ->
+        user && user.id == project.user_id || user.is_admin
       true -> false
     end
   end

--- a/lib/digital_public_works_web/router.ex
+++ b/lib/digital_public_works_web/router.ex
@@ -24,6 +24,12 @@ defmodule DigitalPublicWorksWeb.Router do
     resources "/projects", ProjectController do
       resources "/posts", PostController
     end
+
+    scope "/projects/:id" do
+      put "/publish", ProjectController, :publish
+      put "/unpublish", ProjectController, :unpublish
+    end
+
     resources "/user", UserController, singleton: true
     resources "/session", SessionController, singleton: true
   end

--- a/lib/digital_public_works_web/templates/project/_project.html.eex
+++ b/lib/digital_public_works_web/templates/project/_project.html.eex
@@ -1,10 +1,12 @@
 <div class="card my-4">
   <div class="card-body">
-    <h5 class="card-title"><%= @project.title %>
-      <%= if not @project.is_public do %>
-        <a class="btn-warning" href="<%= Routes.project_path(@conn, :edit, @project.id) %>">Needs Review</a>
-      <%= end %>
-    </h5>
+      <%= unless @project.is_public do %>
+        <%= link "Unpublished",
+          to: Routes.project_path(@conn, :show, @project),
+          class: "badge badge-warning float-right ml-2 mb-2"
+        %>
+      <% end %>
+    <h5 class="card-title"><%= @project.title %></h5>
     <p class="card-text"><%= @project.body %></p>
     <a class="btn btn-primary" href="<%= Routes.project_path(@conn, :show, @project) %>">I can help</a>
     <a class="btn btn-default" href="<%= Routes.project_path(@conn, :show, @project) %>">Learn more</a>

--- a/lib/digital_public_works_web/templates/project/_project.html.eex
+++ b/lib/digital_public_works_web/templates/project/_project.html.eex
@@ -1,6 +1,10 @@
 <div class="card my-4">
   <div class="card-body">
-    <h5 class="card-title"><%= @project.title %></h5>
+    <h5 class="card-title"><%= @project.title %>
+      <%= if not @project.is_public do %>
+        <a class="btn-warning" href="<%= Routes.project_path(@conn, :edit, @project.id) %>">Needs Review</a>
+      <%= end %>
+    </h5>
     <p class="card-text"><%= @project.body %></p>
     <a class="btn btn-primary" href="<%= Routes.project_path(@conn, :show, @project) %>">I can help</a>
     <a class="btn btn-default" href="<%= Routes.project_path(@conn, :show, @project) %>">Learn more</a>

--- a/lib/digital_public_works_web/templates/project/_projects.html.eex
+++ b/lib/digital_public_works_web/templates/project/_projects.html.eex
@@ -1,6 +1,3 @@
-<% is_admin = (@conn.assigns[:current_user] != nil) and @conn.assigns[:current_user].is_admin %>
 <%= for project <- @projects do %>
-  <%= if project.is_public or is_admin do %>
-    <%= render "_project.html", project: project, conn: @conn %>
-  <%= end %>
-<%= end %>
+  <%= render "_project.html", project: project, conn: @conn %>
+<% end %>

--- a/lib/digital_public_works_web/templates/project/_projects.html.eex
+++ b/lib/digital_public_works_web/templates/project/_projects.html.eex
@@ -1,3 +1,6 @@
+<% is_admin = (@conn.assigns[:current_user] != nil) and @conn.assigns[:current_user].is_admin %>
 <%= for project <- @projects do %>
-<%= render "_project.html", project: project, conn: @conn %>
-<% end %>
+  <%= if project.is_public or is_admin do %>
+    <%= render "_project.html", project: project, conn: @conn %>
+  <%= end %>
+<%= end %>

--- a/lib/digital_public_works_web/templates/project/form.html.eex
+++ b/lib/digital_public_works_web/templates/project/form.html.eex
@@ -1,7 +1,13 @@
+<% is_admin = (@conn.assigns[:current_user] != nil) and @conn.assigns[:current_user].is_admin %>
+
 <%= form_for @changeset, @action, [autocomplete: "off"], fn f -> %>
   <%= PBF.text_input f, :title %>
 
   <%= PBF.textarea f, :body, [input: [rows: 10]] %>
+
+  <%= if is_admin do %>
+    <%= PBF.checkbox f, :is_public, label: [text: "Is Public"] %>
+  <%= end %>
 
   <%= PBF.submit f, "Submit project for consideration", class: "btn btn-primary float-right" %>
 <% end %>

--- a/lib/digital_public_works_web/templates/project/form.html.eex
+++ b/lib/digital_public_works_web/templates/project/form.html.eex
@@ -1,13 +1,7 @@
-<% is_admin = (@conn.assigns[:current_user] != nil) and @conn.assigns[:current_user].is_admin %>
-
 <%= form_for @changeset, @action, [autocomplete: "off"], fn f -> %>
   <%= PBF.text_input f, :title %>
 
   <%= PBF.textarea f, :body, [input: [rows: 10]] %>
-
-  <%= if is_admin do %>
-    <%= PBF.checkbox f, :is_public, label: [text: "Is Public"] %>
-  <%= end %>
 
   <%= PBF.submit f, "Submit project for consideration", class: "btn btn-primary float-right" %>
 <% end %>

--- a/lib/digital_public_works_web/templates/project/show.html.eex
+++ b/lib/digital_public_works_web/templates/project/show.html.eex
@@ -1,15 +1,23 @@
-<div class="row">
-  <div class="col">
-    <%= link "< Back", to: Routes.project_path(@conn, :index) %>
-  </div>
-  <%= if can? @current_user, :edit, @project do %>
-    <div class="col text-right">
-      <%= link "Edit", to: Routes.project_path(@conn, :edit, @project) %>
-    </div>
-  <% end %>
-</div>
+<%= link "< Back", to: Routes.project_path(@conn, :index), class: "btn btn-link" %>
 
-<h6 class="text-muted mt-4">PROBLEM</h6>
+<%= if can? @current_user, :edit, @project do %>
+  <%= link "Edit", to: Routes.project_path(@conn, :edit, @project), class: "btn btn-link float-right" %>
+<% end %>
+
+<%= if can? @current_user, :publish, @project do %>
+  <%= link "Publish", to: Routes.project_path(@conn, :publish, @project), method: :put, class: "btn btn-link float-right" %>
+<% end %>
+
+<%= if can? @current_user, :unpublish, @project do %>
+  <%= link "Unpublish", to: Routes.project_path(@conn, :unpublish, @project), method: :put, class: "btn btn-link float-right" %>
+<% end %>
+
+
+<h6 class="text-muted mt-4">PROBLEM
+<%= unless @project.is_public do %>
+  <div class="badge badge-warning float-right">Unpublished</div>
+<% end %>
+</h6>
 <h2><%= @project.title %></h2>
 
 <h6 class="text-muted mt-4">DETAILS</h6>

--- a/priv/repo/migrations/20200125194841_add_is_admin_and_is_public_fields.exs
+++ b/priv/repo/migrations/20200125194841_add_is_admin_and_is_public_fields.exs
@@ -1,0 +1,12 @@
+defmodule DigitalPublicWorks.Repo.Migrations.AddIsAdminAndIsPublicFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :is_admin, :boolean, default: :false
+    end
+    alter table(:projects) do
+      add :is_public, :boolean, default: :false
+    end
+  end
+end

--- a/test/digital_public_works/projects_test.exs
+++ b/test/digital_public_works/projects_test.exs
@@ -9,9 +9,26 @@ defmodule DigitalPublicWorks.ProjectsTest do
     @update_attrs %{body: "some updated body", title: "some updated title"}
     @invalid_attrs %{body: nil, title: nil}
 
-    test "list_projects/0 returns all projects" do
-      project = Repo.get(Project, insert(:project, is_public: true).id)
-      assert Projects.list_projects() == [project]
+    test "list_projects/2 returns all projects" do
+      owner = insert(:user)
+      other = insert(:user)
+      admin = insert(:user, is_admin: true)
+
+      project = Repo.get(Project, insert(:project, user: owner).id)
+
+      assert Projects.list_projects(owner) == [project]
+      assert Projects.list_projects(admin) == [project]
+      assert Projects.list_projects(other) == []
+      assert Projects.list_projects        == []
+
+      project = project
+      |> Ecto.Changeset.change(is_public: true)
+      |> Repo.update!
+
+      assert Projects.list_projects(owner) == [project]
+      assert Projects.list_projects(admin) == [project]
+      assert Projects.list_projects(other) == [project]
+      assert Projects.list_projects        == [project]
     end
 
     test "get_project!/1 returns the project with given id" do

--- a/test/digital_public_works/projects_test.exs
+++ b/test/digital_public_works/projects_test.exs
@@ -10,7 +10,7 @@ defmodule DigitalPublicWorks.ProjectsTest do
     @invalid_attrs %{body: nil, title: nil}
 
     test "list_projects/0 returns all projects" do
-      project = Repo.get(Project, insert(:project).id)
+      project = Repo.get(Project, insert(:project, is_public: true).id)
       assert Projects.list_projects() == [project]
     end
 

--- a/test/digital_public_works_web/controllers/project_controller_test.exs
+++ b/test/digital_public_works_web/controllers/project_controller_test.exs
@@ -140,4 +140,47 @@ defmodule DigitalPublicWorksWeb.ProjectControllerTest do
     end
   end
 
+  describe "publish project" do
+    @tag :as_user
+    test  "user can't publish project", %{conn: conn, user: user} do
+      project = insert(:project, user: user)
+
+      conn = put(conn, Routes.project_path(conn, :publish, project))
+
+      assert redirected_to(conn) == Routes.page_path(conn, :index)
+      assert get_flash(conn, :error) =~ "You don't have access to that"
+    end
+
+    @tag :as_admin
+    test  "admin can publish project", %{conn: conn} do
+      project = insert(:project)
+
+      conn = put(conn, Routes.project_path(conn, :publish, project))
+
+      assert redirected_to(conn) == Routes.project_path(conn, :show, project)
+      assert get_flash(conn, :info) =~ "Project published successfully"
+    end
+  end
+
+  describe "unpublish project" do
+    @tag :as_user
+    test  "user can't unpublish project", %{conn: conn, user: user} do
+      project = insert(:project, user: user, is_public: true)
+
+      conn = put(conn, Routes.project_path(conn, :unpublish, project))
+
+      assert redirected_to(conn) == Routes.page_path(conn, :index)
+      assert get_flash(conn, :error) =~ "You don't have access to that"
+    end
+
+    @tag :as_admin
+    test  "admin can unpublish project", %{conn: conn} do
+      project = insert(:project, is_public: true)
+
+      conn = put(conn, Routes.project_path(conn, :unpublish, project))
+
+      assert redirected_to(conn) == Routes.project_path(conn, :show, project)
+      assert get_flash(conn, :info) =~ "Project unpublished successfully"
+    end
+  end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -14,6 +14,7 @@ defmodule DigitalPublicWorksWeb.ConnCase do
   """
 
   use ExUnit.CaseTemplate
+  import DigitalPublicWorks.Factory
 
   using do
     quote do
@@ -36,7 +37,8 @@ defmodule DigitalPublicWorksWeb.ConnCase do
     end
 
     user = cond do
-      tags[:as_user] -> DigitalPublicWorks.Factory.insert(:user)
+      tags[:as_user] -> insert(:user)
+      tags[:as_admin] -> insert(:user, is_admin: true)
       true -> nil
     end
 


### PR DESCRIPTION
First pass at project review. Looking for buy-in / suggestions.

- add Is_public field to project
- add is_admin field to user
- non-public projects only show up on admin's project view
- admins can edit any project
- admin edit form has "Is Public" checkbox (does not show up for owner)

Todo
- edit user to have admin. Currently have to manually edit database, which is sad.
- is_public field is not sufficiently protected. It doesn't display on owner's edit form, but it is in their changeset, so they could edit the form to include it.
- tests.