### PR TITLE
Password Reset

### DIFF
--- a/lib/digital_public_works/accounts/user.ex
+++ b/lib/digital_public_works/accounts/user.ex
@@ -13,6 +13,9 @@ defmodule DigitalPublicWorks.Accounts.User do
     field :password, :string, virtual: true
     field :password_hash, :string
     field :is_admin, :boolean, default: :false
+    field :reset_token, :string
+    field :reset_sent_at, :naive_datetime
+
     has_many :projects, Project
     many_to_many :followed_projects, Project, join_through: ProjectFollower
 

--- a/lib/digital_public_works_web/controllers/password_reset_controller.ex
+++ b/lib/digital_public_works_web/controllers/password_reset_controller.ex
@@ -1,0 +1,65 @@
+defmodule DigitalPublicWorksWeb.PasswordResetController do
+  use DigitalPublicWorksWeb, :controller
+  alias DigitalPublicWorks.Accounts
+
+  plug :get_user
+
+  defp get_user(%{params: %{"reset_token" => reset_token}} = conn, _args) do
+    conn
+    |> assign(:user, Accounts.get_password_reset!(reset_token))
+  rescue
+    _ ->
+      conn
+      |> put_flash(:error, "Invalid password reset token")
+      |> redirect(to: Routes.password_reset_path(conn, :new))
+      |> halt()
+  end
+
+  defp get_user(conn, _args), do: conn
+
+  def new(conn, _args) do
+    conn
+    |> render("new.html")
+  end
+
+  def create(conn, %{"email" => email}) do
+    case Accounts.get_user_by(%{"email" => email}) do
+      nil ->
+        conn
+        |> put_flash(:error, "Account not found")
+        |> render("new.html")
+
+      user ->
+        {:ok, user} = Accounts.create_password_reset(user)
+
+        user
+        |> DigitalPublicWorksWeb.Email.password_reset()
+        |> DigitalPublicWorksWeb.Mailer.deliver_now()
+
+        conn
+        |> put_flash(:info, "Password reset email sent to #{email}")
+        |> render("new.html")
+    end
+  end
+
+  def edit(conn, _params) do
+    conn
+    |> render("edit.html")
+  end
+
+  def update(%{assigns: %{user: user}} = conn, %{"password" => password}) do
+    case Accounts.update_password_reset(user, %{"password" => password}) do
+      {:ok, user} ->
+        conn
+        |> put_session(:current_user_id, user.id)
+        |> configure_session(renew: true)
+        |> put_flash(:info, "Password reset successfully.")
+        |> redirect(to: Routes.page_path(conn, :index))
+
+      {:error, _changeset} ->
+        conn
+        |> put_flash(:error, "Error updating password")
+        |> render("edit.html")
+    end
+  end
+end

--- a/lib/digital_public_works_web/email.ex
+++ b/lib/digital_public_works_web/email.ex
@@ -8,6 +8,14 @@ defmodule DigitalPublicWorksWeb.Email do
     |> render("welcome.text")
   end
 
+  def password_reset(user) do
+    base_email()
+    |> assign(:reset_token, user.reset_token)
+    |> to(user)
+    |> subject("Reset Password")
+    |> render("password_reset.text")
+  end
+
   defp base_email do
     new_email()
     |> from("Digital Public Works <support@digitalpublicworks.com>")

--- a/lib/digital_public_works_web/router.ex
+++ b/lib/digital_public_works_web/router.ex
@@ -36,6 +36,11 @@ defmodule DigitalPublicWorksWeb.Router do
 
     resources "/user", UserController, singleton: true
     resources "/session", SessionController, singleton: true
+
+    get "/forgot_password", PasswordResetController, :new
+    post "/forgot_passowrd", PasswordResetController, :create
+    get "/update_password/:reset_token", PasswordResetController, :edit
+    post "/update_password/:reset_token", PasswordResetController, :update
   end
 
   scope "/" do

--- a/lib/digital_public_works_web/templates/email/password_reset.text.eex
+++ b/lib/digital_public_works_web/templates/email/password_reset.text.eex
@@ -1,0 +1,3 @@
+Use the following link to reset your password <%= Routes.password_reset_url(DigitalPublicWorksWeb.Endpoint, :edit, @reset_token) %>
+
+This link expires in 10 minutes.

--- a/lib/digital_public_works_web/templates/password_reset/edit.html.eex
+++ b/lib/digital_public_works_web/templates/password_reset/edit.html.eex
@@ -1,0 +1,13 @@
+<div class="row justify-content-center">
+  <div class="col col-main-small">
+    <div class="card mb-4">
+      <div class="card-body">
+        <h3 class="card-title">Update Password</h3>
+        <%= form_for @conn, Routes.password_reset_path(@conn, :update, @user.reset_token), fn f -> %>
+          <%= PBF.password_input f, :password, [input: [autofocus: true]] %>
+          <%= PBF.submit f, "Update Password", class: "btn btn-primary float-right" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/digital_public_works_web/templates/password_reset/new.html.eex
+++ b/lib/digital_public_works_web/templates/password_reset/new.html.eex
@@ -1,0 +1,13 @@
+<div class="row justify-content-center">
+  <div class="col col-main-small">
+    <div class="card mb-4">
+      <div class="card-body">
+        <h3 class="card-title">Reset Password</h3>
+        <%= form_for @conn, Routes.password_reset_path(@conn, :create), [], fn f -> %>
+          <%= PBF.text_input f, :email, [input: [autofocus: true]] %>
+          <%= PBF.submit f, "Send Reset Email", class: "btn btn-primary float-right" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/digital_public_works_web/templates/session/new.html.eex
+++ b/lib/digital_public_works_web/templates/session/new.html.eex
@@ -20,6 +20,7 @@
         <% end %>
       </div>
     </div>
+    <p class="text-center"><%= link "Forgot your password?", to: Routes.password_reset_path(@conn, :new) %></p>
     <p class="text-center">New to Digital Public Works? <%= link "Sign Up", to: Routes.user_path(@conn, :new) %></p>
   </div>
 </div>

--- a/lib/digital_public_works_web/views/password_reset_view.ex
+++ b/lib/digital_public_works_web/views/password_reset_view.ex
@@ -1,0 +1,3 @@
+defmodule DigitalPublicWorksWeb.PasswordResetView do
+  use DigitalPublicWorksWeb, :view
+end

--- a/priv/repo/migrations/20200318191523_add_password_reset_to_users.exs
+++ b/priv/repo/migrations/20200318191523_add_password_reset_to_users.exs
@@ -1,0 +1,12 @@
+defmodule DigitalPublicWorks.Repo.Migrations.AddPasswordResetToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :reset_token, :string
+      add :reset_sent_at, :naive_datetime
+    end
+
+    create unique_index(:users, [:reset_token])
+  end
+end

--- a/test/digital_public_works_web/controllers/password_reset_controller_test.exs
+++ b/test/digital_public_works_web/controllers/password_reset_controller_test.exs
@@ -1,0 +1,45 @@
+defmodule DigitalPublicWorksWeb.PasswordResetControllerTest do
+  use DigitalPublicWorksWeb.ConnCase
+
+  test "shows forgot password screen", %{conn: conn} do
+    conn = get(conn, Routes.password_reset_path(conn, :new))
+    assert html_response(conn, 200) =~ "Reset Password"
+  end
+
+  test "show error when attempting to reset missing email", %{conn: conn} do
+    conn = post(conn, Routes.password_reset_path(conn, :create, %{email: "1234"}))
+    assert get_flash(conn, :error) =~ "Account not found"
+  end
+
+  test "creates password reset", %{conn: conn} do
+    user = insert(:user)
+
+    conn = post(conn, Routes.password_reset_path(conn, :create, %{email: user.email}))
+    assert get_flash(conn, :info) =~ "Password reset email sent to #{user.email}"
+
+    user
+    |> Map.get(:id)
+    |> DigitalPublicWorks.Accounts.get_user!()
+    |> DigitalPublicWorksWeb.Email.password_reset()
+    |> assert_delivered_email()
+  end
+
+  test "show update password screen", %{conn: conn} do
+    user = insert(:reset_user)
+    conn = get(conn, Routes.password_reset_path(conn, :edit, user.reset_token))
+    assert html_response(conn, 200) =~ "Update Password"
+  end
+
+  test "show error when user is trying to access password update screen with invalid token", %{conn: conn} do
+    conn = get(conn, Routes.password_reset_path(conn, :edit, "1234"))
+    assert get_flash(conn, :error) =~ "Invalid password reset token"
+  end
+
+  test "update password via password reset", %{conn: conn} do
+    user = insert(:reset_user)
+    new_password = "newpassword"
+
+    conn = post(conn, Routes.password_reset_path(conn, :update, user.reset_token, %{password: new_password}))
+    assert get_flash(conn, :info) =~ "Password reset successfully"
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -26,6 +26,8 @@ defmodule DigitalPublicWorksWeb.ConnCase do
       @endpoint DigitalPublicWorksWeb.Endpoint
 
       import DigitalPublicWorks.Factory
+
+      use Bamboo.Test
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -12,6 +12,19 @@ defmodule DigitalPublicWorks.Factory do
     }
   end
 
+  def reset_user_factory() do
+    reset_sent_at =
+      NaiveDateTime.utc_now()
+      |> NaiveDateTime.truncate(:second)
+
+    reset_token = DigitalPublicWorks.Accounts.generate_url_safe_token()
+
+    struct!(
+      user_factory(),
+      %{reset_token: reset_token, reset_sent_at: reset_sent_at}
+    )
+  end
+
   def project_factory do
     %Project{
       title: sequence(:email, &"Project #{&1}"),


### PR DESCRIPTION
Most of the functionality is in, there are just a few things missing.

The error handling when updating a password reset only shows a generic error. We need to figure out a way to handle both a password requirement error (i.e. length is less than 8 characters) and a token expiration error, without needing to duplicate the existing user changeset constraints. Perhaps this could be done with a new changeset?

The existing user changeset allows password to be null when doing an update. This leads to the  situation where leaving the password field blank and clicking Update Password gives the user the message that the password was updated successfully, when in reality the password is still the same and they will need to request another password update.

I started the implementation by having a separate PasswordReset table and struct but I think adding two columns directly to the user table is a cleaner solution. The unit tests are a little wonky because they were created using a generator when I was implementing this via a separate table.